### PR TITLE
compute MP3 time and bitrate on demand

### DIFF
--- a/src/commands/get.rs
+++ b/src/commands/get.rs
@@ -24,13 +24,15 @@ pub fn run(property: &str, files: &[String], short: bool) -> anyhow::Result<()> 
 
 fn info_for_file(property: &str, file: &Path) -> anyhow::Result<String> {
     let data = AurMetadata::new(file)?;
+    let quality = data.quality();
+    let time = data.time();
 
     let ret = match property {
-        "bit_depth" => data.quality.bit_depth.to_string(),
-        "sample_rate" => data.quality.sample_rate.to_string(),
-        "bitrate" => data.quality.formatted,
-        "time" => data.time.formatted,
-        "time_raw" => data.time.raw.to_string(),
+        "bit_depth" => quality.bit_depth.to_string(),
+        "sample_rate" => quality.sample_rate.to_string(),
+        "bitrate" => quality.formatted,
+        "time" => time.formatted,
+        "time_raw" => time.raw.to_string(),
         _ => data.get_tag(property)?,
     };
 
@@ -51,7 +53,7 @@ mod test {
     use crate::utils::spec_helper::fixture;
 
     #[test]
-    fn test_info_for_file() {
+    fn test_get_bitrate() {
         assert_eq!(
             "16-bit/44100Hz",
             info_for_file("bitrate", &fixture("info/test.flac")).unwrap()

--- a/src/commands/info.rs
+++ b/src/commands/info.rs
@@ -17,10 +17,10 @@ pub fn run(files: &[String]) -> anyhow::Result<()> {
 fn info_for_file(file: &Path) -> anyhow::Result<Vec<String>> {
     let data = AurMetadata::new(file)?;
     let fields: Vec<(&str, String)> = vec![
-        ("Filename", data.filename),
+        ("Filename", data.filename.clone()),
         ("Type", data.filetype.to_uppercase()),
-        ("Bitrate", data.quality.formatted),
-        ("Time", data.time.formatted),
+        ("Bitrate", data.quality().formatted),
+        ("Time", data.time().formatted),
         ("Artist", data.tags.artist),
         ("Album", data.tags.album),
         ("Title", data.tags.title),

--- a/src/utils/metadata.rs
+++ b/src/utils/metadata.rs
@@ -250,12 +250,15 @@ impl AurQuality {
 
     fn from_mp3(path: &PathBuf, metadata: &MP3Metadata) -> Self {
         let file_size = fs::metadata(path).unwrap().len();
-        let duration_sec = metadata.duration.as_secs();
+        let duration = metadata.duration.as_secs();
 
-        let bitrate = if duration_sec > 0 {
-            file_size * 8 / duration_sec / 1000
+        let bitrate = if duration > 0 {
+            file_size * 8 / duration / 1000
         } else {
-            0
+            match metadata.frames.first().map(|f| f.bitrate) {
+                Some(bitrate) => bitrate as u64,
+                None => 0,
+            }
         };
 
         Self {

--- a/src/utils/mp3_encoder.rs
+++ b/src/utils/mp3_encoder.rs
@@ -253,8 +253,8 @@ mod test {
         let mp3_info = AurMetadata::new(&mp3_file).unwrap();
 
         assert_eq!(&flac_info.tags, &mp3_info.tags);
-        assert_eq!(&flac_info.time.raw, &mp3_info.time.raw);
-        assert!(mp3_info.quality.bit_depth >= 128);
+        assert_eq!(&flac_info.time().raw, &mp3_info.time().raw);
+        assert!(mp3_info.quality().bit_depth >= 128);
     }
 
     #[test]

--- a/src/utils/mp3_encoder.rs
+++ b/src/utils/mp3_encoder.rs
@@ -254,7 +254,7 @@ mod test {
 
         assert_eq!(&flac_info.tags, &mp3_info.tags);
         assert_eq!(&flac_info.time().raw, &mp3_info.time().raw);
-        assert!(mp3_info.quality().bit_depth >= 128);
+        assert!(mp3_info.quality().sample_rate >= 128);
     }
 
     #[test]


### PR DESCRIPTION
Use a crude but very fast and accurate-enough way of calculating MP3 bitrate. And only calculate duration and bitrate when they are requested. Getting them at metadata create time meant recursive lints etc took a very long time.