### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test 
+permissions:
+  contents: read
 on: 
   - push
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/snltd/aur-rs/security/code-scanning/1](https://github.com/snltd/aur-rs/security/code-scanning/1)

To fix this issue, you should explicitly add a `permissions` block to the workflow or to the job definition. The minimal starting point that adheres to the principle of least privilege is `contents: read`, which allows the workflow to read repository contents, sufficient for checking out code and running tests, but does not permit writing to the repository or performing administrative actions. Add the following block to the top-level section of the workflow (recommended for consistency and simplicity) immediately after the `name:` declaration or before the `jobs:` block. No additional libraries, imports, or methods are needed; this change is entirely within the workflow YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
